### PR TITLE
Fix #56: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Create a report to fix the specification
+
+---
+
+**Describe the issue**
+A clear and concise description of what the problem is in the spec.
+
+If you need help on how to use WebAudio, ask on your favorite forum or consider visiting
+the [WebAudio Slack Channel](https://web-audio.slack.com/) (register [here](https://web-audio-slackin.herokuapp.com/)) or
+[StackOverflow](https://stackoverflow.com/).
+
+**Where Is It**
+Provide a link to where the problem is in the spec
+
+**Additional Information**
+Provide any additional information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Suggest additions for WebAudio
+
+---
+**Describe the feature**
+Briefly describe the feature you would like WebAudio to have.
+
+**Is there a prototype?**
+If you have a prototype (possibly using an AudioWorkletNode), provide links to illustrate this addition.  This is the best way to propose a new feature.
+
+**Describe the feature in more detail**
+Provide more information how it does and how it works.


### PR DESCRIPTION
Add issue templates for bug reports and feature requests.

Basically copied the templates from the v1 repo, unchanged.