### PR TITLE
Add label for new bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to fix the specification
 title: ''
-labels: ''
+labels: Ne
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to fix the specification
 title: ''
-labels: Ne
+labels: Needs WG Review
 assignees: ''
 
 ---


### PR DESCRIPTION
When new issues are created, automatically add the "Needs WG Review" label so we can find them easily and note that they need to be reviewed.  After reviewing, the label should be removed.